### PR TITLE
Define a formatter for SQL (sqlformat)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Supported languages
 * **Ruby** (*rufo*)
 * **Rust** (*rustfmt*)
 * **Shell script** (*shfmt*)
+* **SQL** (*sqlformat*)
 * **Swift** (*swiftformat*)
 
 How to install

--- a/format-all.el
+++ b/format-all.el
@@ -36,6 +36,7 @@
 ;; - Ruby (rufo)
 ;; - Rust (rustfmt)
 ;; - Shell script (shfmt)
+;; - SQL (sqlformat)
 ;; - Swift (swiftformat)
 ;;
 ;; You will need to install external programs to do the formatting.
@@ -270,6 +271,12 @@ EXECUTABLE is the full path to the formatter."
    "-ln" (cl-case (and (boundp 'sh-shell) (symbol-value 'sh-shell))
            (bash "bash") (mksh "mksh") (t "posix"))))
 
+(defun format-all-buffer-sqlformat (executable)
+  "Format the current buffer as SQL using \"sqlformat\".
+
+EXECUTABLE is the full path to the formatter."
+  (format-all-buffer-process executable nil nil "-k" "upper" "-a" "-"))
+
 (defun format-all-buffer-standard (executable)
   "Format the current buffer as JavaScript using \"standard\".
 
@@ -362,6 +369,11 @@ EXECUTABLE is the full path to the formatter."
      (:install (darwin "brew install shfmt"))
      (:function format-all-buffer-shfmt)
      (:modes sh-mode))
+    (sqlformat
+     (:executable "sqlformat")
+     (:install "pip install sqlparse")
+     (:function format-all-buffer-sqlformat)
+     (:modes sql-mode))
     (standard
      (:executable "standard")
      (:install "npm install standard")

--- a/format-all.el
+++ b/format-all.el
@@ -275,7 +275,19 @@ EXECUTABLE is the full path to the formatter."
   "Format the current buffer as SQL using \"sqlformat\".
 
 EXECUTABLE is the full path to the formatter."
-  (format-all-buffer-process executable nil nil "-k" "upper" "-a" "-"))
+  (let* ((ic (car default-process-coding-system))
+         (oc (cdr default-process-coding-system))
+         (ienc (symbol-name (or (coding-system-get ic :mime-charset) 'utf-8)))
+         (oenc (symbol-name (or (coding-system-get oc :mime-charset) 'utf-8)))
+         (process-environment (cons (concat "PYTHONIOENCODING=" oenc)
+                                    process-environment)))
+    (format-all-buffer-process
+     executable
+     nil nil
+     "--keywords" "upper"
+     "--reindent_aligned"
+     "--encoding" ienc
+     "-")))
 
 (defun format-all-buffer-standard (executable)
   "Format the current buffer as JavaScript using \"standard\".


### PR DESCRIPTION
It uses sqlformat from the Python package "sqlparse" with some options of choice:

- `-k upper`: to uppercase keywords
- `-a`: to get a multiline, aligned output