### PR TITLE
Support Terraform via 'terraform fmt'

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Supported languages
 * **Shell script** ([*shfmt*](https://github.com/mvdan/sh))
 * **SQL** ([*sqlformat*](https://pypi.org/project/sqlparse/))
 * **Swift** ([*swiftformat*](https://github.com/nicklockwood/SwiftFormat))
+* **Terraform** ([*terraform fmt*](https://www.terraform.io/docs/commands/fmt.html))
 * **TypeScript/TSX** ([*prettier*](https://prettier.io/))
 * **YAML** ([*yq*](https://github.com/mikefarah/yq))
 

--- a/format-all.el
+++ b/format-all.el
@@ -52,6 +52,7 @@
 ;; - Shell script (shfmt)
 ;; - SQL (sqlformat)
 ;; - Swift (swiftformat)
+;; - Terraform (terraform fmt)
 ;; - TypeScript/TSX (prettier)
 ;; - YAML (yq)
 ;;
@@ -530,6 +531,12 @@ Consult the existing formatters for examples of BODY."
   (:install (macos "brew install swiftformat"))
   (:modes swift-mode swift3-mode)
   (:format (format-all-buffer-easy executable)))
+
+(define-format-all-formatter terraform-fmt
+  (:executable "terraform")
+  (:install (macos "brew install terraform"))
+  (:modes terraform-mode)
+  (:format (format-all-buffer-easy executable "fmt" "-no-color" "-")))
 
 (define-format-all-formatter yq
   (:executable "yq")


### PR DESCRIPTION
Hey there 👋 Great package.

This adds support for the [terraform configuration language](https://www.terraform.io/docs/configuration/index.html) by running `terraform fmt -`. 

* Before
```tf
provider "aws" {
  region                               = "${var.region}"
  shared_credentials_file = "${var.credentials_aws_file}"
  profile     = "tf"
  version                    = "~> 2.5"
}
```
* After
```tf
provider "aws" {
  region                  = "${var.region}"
  shared_credentials_file = "${var.credentials_aws_file}"
  profile                 = "tf"
  version                 = "~> 2.5"
}
```