### PR TITLE
Add support for Bazel Starlark using buildifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Supported languages
 
 * **Angular/Vue** ([*prettier*](https://prettier.io/))
 * **Assembly** ([*asmfmt*](https://github.com/klauspost/asmfmt))
+* **Bazel Starlark** (https://github.com/bazelbuild/buildtools/tree/master/buildifier)
 * **BibTeX** (emacs)
 * **C/C++/Objective-C** ([*clang-format*](https://clang.llvm.org/docs/ClangFormat.html))
 * **Clojure/ClojureScript** ([*node-cljfmt*](https://github.com/snoe/node-cljfmt))

--- a/format-all.el
+++ b/format-all.el
@@ -24,6 +24,7 @@
 ;;
 ;; - Angular/Vue (prettier)
 ;; - Assembly (asmfmt)
+;; - Bazel Starlark (buildifier)
 ;; - BibTeX (emacs)
 ;; - C/C++/Objective-C (clang-format)
 ;; - Clojure/ClojureScript (node-cljfmt)
@@ -367,6 +368,12 @@ Consult the existing formatters for examples of BODY."
             executable "-q"
             (when (format-all--buffer-extension-p "pyi") "--pyi")
             "-")))
+
+(define-format-all-formatter buildifier
+  (:executable "buildifier")
+  (:install "go get github.com/bazelbuild/buildtools/buildifier")
+  (:modes bazel-mode)
+  (:format (format-all--buffer-easy executable)))
 
 (define-format-all-formatter brittany
   (:executable "brittany")


### PR DESCRIPTION
Adds support for Bazel Starlark (https://docs.bazel.build/versions/master/skylark/language.html) using buildifier (https://github.com/bazelbuild/buildtools/tree/master/buildifier)