### PR TITLE
fix: switch YAML from yq to prettier.

### DIFF
--- a/format-all.el
+++ b/format-all.el
@@ -59,7 +59,7 @@
 ;; - Swift (swiftformat)
 ;; - Terraform (terraform fmt)
 ;; - TypeScript/TSX (prettier)
-;; - YAML (yq)
+;; - YAML (prettier)
 ;;
 ;; You will need to install external programs to do the formatting.
 ;; If `format-all-buffer` can't find the right program, it will try to
@@ -557,7 +557,8 @@ Consult the existing formatters for examples of BODY."
                    ((equal en "vue") "vue")
                    ((equal en "none") "html")
                    (t nil)))
-            (t nil)))))
+            (t nil))))
+   (yaml-mode "yaml"))
   (:format
    (let ((parser mode-result))
      (format-all--buffer-easy
@@ -625,12 +626,6 @@ Consult the existing formatters for examples of BODY."
   (:install (macos "brew install terraform"))
   (:modes terraform-mode)
   (:format (format-all--buffer-easy executable "fmt" "-no-color" "-")))
-
-(define-format-all-formatter yq
-  (:executable "yq")
-  (:install (macos "brew install yq"))
-  (:modes yaml-mode)
-  (:format (format-all--buffer-easy executable "read" "-")))
 
 (defun format-all--please-install (executable installer)
   "Internal helper function for error about missing EXECUTABLE and INSTALLER."


### PR DESCRIPTION
I encountered the following error when formatting a YAML file with yq:

    jq: error: read/0 is not defined at <top-level>, line 1:
    read
    jq: 1 compile error

Because the formatter yq use the wrong arguments, the "read" argument must change to ".",
see https://github.com/kislyuk/yq/issues/50 for more information.

Because prettier already support formatting YAML, switch to it is better, this
also solve the issue https://github.com/lassik/emacs-format-all-the-code/issues/39