### PR TITLE
add fish shell support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Supported languages
 * **Elixir** ([*mix format*](https://hexdocs.pm/mix/master/Mix.Tasks.Format.html))
 * **Elm** ([*elm-format*](https://github.com/avh4/elm-format))
 * **Emacs Lisp** (emacs)
+* **Fish Shell** ([*fish_indent*](https://fishshell.com/docs/current/commands.html#fish_indent))
 * **Go** ([*gofmt*](https://golang.org/cmd/gofmt/))
 * **GraphQL** ([*prettier*](https://prettier.io/))
 * **Haskell** ([*brittany*](https://github.com/lspitzner/brittany))

--- a/format-all.el
+++ b/format-all.el
@@ -38,6 +38,7 @@
 ;; - Elixir (mix format)
 ;; - Elm (elm-format)
 ;; - Emacs Lisp (emacs)
+;; - Fish Shell (fish_indent)
 ;; - Go (gofmt)
 ;; - GraphQL (prettier)
 ;; - Haskell (brittany)
@@ -472,6 +473,12 @@ Consult the existing formatters for examples of BODY."
    (format-all--buffer-native
     'emacs-lisp-mode
     (lambda () (indent-region (point-min) (point-max))))))
+
+(define-format-all-formatter fish-indent
+  (:executable "fish_indent")
+  (:install (macos "brew install fish OR port install fish"))
+  (:modes fish-mode)
+  (:format (format-all--buffer-easy executable)))
 
 (define-format-all-formatter gofmt
   (:executable "gofmt")


### PR DESCRIPTION
Added support for formatting fish shell code using the built-in [fish_indent](https://fishshell.com/docs/current/commands.html#fish_indent)