### PR TITLE
Fix mix format ignores config in subdirectories

### DIFF
--- a/format-all.el
+++ b/format-all.el
@@ -546,7 +546,15 @@ Consult the existing formatters for examples of BODY."
   (:install (macos "brew install elixir"))
   (:modes elixir-mode)
   (:format
-   (format-all--buffer-hard nil nil '("mix.exs") executable "format" "-")))
+   (format-all--buffer-hard
+    nil nil '("mix.exs")
+    executable
+    "format"
+    (let* ((file ".formatter.exs")
+           (dir (and (buffer-file-name)
+                     (locate-dominating-file (buffer-file-name) file))))
+      (when dir (list "--dot-formatter" (concat dir file))))
+    "-")))
 
 (define-format-all-formatter nixfmt
   (:executable "nixfmt")


### PR DESCRIPTION
fix #62 

Log when format:
```
;; project with .formatter.exs in subdirectory
Format-All: Formatting create_users.exs as (mix-format t)
Format-All: Running: /Users/james/.asdf/shims/mix format --dot-formatter \~/src/elixir_formatter_playground/priv/subdir/.formatter.exs -
Format-All: Directory: ~/src/elixir_formatter_playground/

;; project without any .formatter.exs
Format-All: Formatting format.ex as (mix-format t)
Format-All: Running: /Users/james/.asdf/shims/mix format -
Format-All: Directory: /Users/james/.asdf/installs/elixir/1.9.4-otp-22/lib/mix/lib/mix/tasks/
```