### PR TITLE
Fix prettier vs html-tidy conflict in web-mode

### DIFF
--- a/format-all.el
+++ b/format-all.el
@@ -606,7 +606,11 @@ Consult the existing formatters for examples of BODY."
             ((equal ct "html")
              (cond ((equal en "angular") "angular")
                    ((equal en "vue") "vue")
-                   ((equal en "none") "html")
+                   ;; TODO: Use html-tidy instead of prettier for
+                   ;; plain HTML. Enable prettier's HTML support once
+                   ;; we have multi-formatter support.
+                   ;;
+                   ;; ((equal en "none") "html")
                    (t nil)))
             (t nil))))
    (yaml-mode "yaml"))


### PR DESCRIPTION
Prettier now has a "html" parser for plain HTML, so both prettier and
html-tidy can format HTML. Format-all currently has rules only for
html-tidy in Emacs' own HTML modes, but has rules for both html-tidy
and prettier in web-mode. By accident, prettier's web-mode rule had
precedence over the html-tidy rule, which would mean that HTML is
sometimes formatted with html-tidy (if you happen to be in html-mode)
but the same HTML file is formatted with prettier instead if you
happen to be in web-mode. That difference is confusing for users.

Solve the problem by disabling prettier for plain HTML. In the future,
the proper fix will be to have multi-formatter support, and support
both prettier and html-tidy in all HTML-related Emacs modes. Then
people can choose which formatter they want.