### PR TITLE
Use "--quiet" option for swiftformat

### DIFF
--- a/format-all.el
+++ b/format-all.el
@@ -704,7 +704,7 @@ Consult the existing formatters for examples of BODY."
   (:executable "swiftformat")
   (:install (macos "brew install swiftformat"))
   (:modes swift-mode swift3-mode)
-  (:format (format-all--buffer-easy executable)))
+  (:format (format-all--buffer-easy executable "--quiet")))
 
 (define-format-all-formatter terraform-fmt
   (:executable "terraform")


### PR DESCRIPTION
When formatting Swift code, the `*format-all-errors*` buffer displays:
```
Running SwiftFormat...
Swiftformat completed successfully.
```
Using the `--quiet` flag disables this message. Only error messages will be displayed.