### PR TITLE
Add "HCL" to terraform languages

### DIFF
--- a/format-all.el
+++ b/format-all.el
@@ -691,7 +691,7 @@ Consult the existing formatters for examples of BODY."
 (define-format-all-formatter terraform-fmt
   (:executable "terraform")
   (:install (macos "brew install terraform"))
-  (:languages "Terraform")
+  (:languages "Terraform" "HCL")
   (:format (format-all--buffer-easy executable "fmt" "-no-color" "-")))
 
 (defun format-all--language-id-buffer ()


### PR DESCRIPTION
Formatting in [terraform-mode](https://github.com/emacsorphanage/terraform-mode) currently reports `Don't know how to format terraform-mode code`.

I believe it has been broken ever since [this commit](https://github.com/lassik/emacs-language-id/commit/34cd1a675e0dc98adbd918fc27a189b5a9e02a61) in emacs-language-id, changing the language for terraform-mode to "HCL".

This commit adds "HCL" to the terraform languages.
emacs-language-id still has `("Terraform" terraform-mode)` in its list, so I kept "Terraform" in the languages.