### PR TITLE
Add (require 'cl-lib)

### DIFF
--- a/format-all.el
+++ b/format-all.el
@@ -96,6 +96,7 @@
 ;;
 ;;; Code:
 
+(require 'cl-lib)
 (require 'language-id)
 
 (defvar format-all-debug nil


### PR DESCRIPTION
Fixes this error when byte-compiling:

```
In toplevel form:
format-all.el:138:66:Error: Symbol’s function definition is void: windows-nt
```
