### PR TITLE
shfmt: Respect .editorconfig configuration

### DIFF
--- a/format-all.el
+++ b/format-all.el
@@ -676,12 +676,14 @@ Consult the existing formatters for examples of BODY."
   (:format
    (format-all--buffer-easy
     executable
-    "-ln" (cl-case (and (eql major-mode 'sh-mode)
-                        (boundp 'sh-shell)
-                        (symbol-value 'sh-shell))
-            (bash "bash")
-            (mksh "mksh")
-            (t "posix")))))
+    (if (buffer-file-name)
+        (list "-filename" (buffer-file-name))
+      (list "-ln" (cl-case (and (eql major-mode 'sh-mode)
+                                (boundp 'sh-shell)
+                                (symbol-value 'sh-shell))
+                    (bash "bash")
+                    (mksh "mksh")
+                    (t "posix")))))))
 
 (define-format-all-formatter snakefmt
   (:executable "snakefmt")


### PR DESCRIPTION
Uses the new `-filename` option of shfmt 3.2.0.  We must avoid passing `-ln` when passing `-filename` because no options are read from `.editorconfig` if any options are passed on the command line.

Fixes #90.