### PR TITLE
Add goimports as a go formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Supported languages
 * **Fish Shell** ([*fish_indent*](https://fishshell.com/docs/current/commands.html#fish_indent))
 * **Fortran 90** ([*fprettify*](https://github.com/pseewald/fprettify))
 * **Gleam** ([*gleam format*](https://gleam.run/))
-* **Go** ([*gofmt*](https://golang.org/cmd/gofmt/))
+* **Go** ([*gofmt*](https://golang.org/cmd/gofmt/)), ([*goimports*](https://godoc.org/golang.org/x/tools/cmd/goimports))
 * **GraphQL** ([*prettier*](https://prettier.io/))
 * **Haskell** ([*brittany*](https://github.com/lspitzner/brittany), [*hindent*](https://github.com/commercialhaskell/hindent), [*stylish-haskell*](https://github.com/jaspervdj/stylish-haskell))
 * **HTML/XHTML/XML** ([*tidy*](http://www.html-tidy.org/))

--- a/format-all.el
+++ b/format-all.el
@@ -43,7 +43,7 @@
 ;; - Fish Shell (fish_indent)
 ;; - Fortran 90 (fprettify)
 ;; - Gleam (gleam format)
-;; - Go (gofmt)
+;; - Go (gofmt, goimports)
 ;; - GraphQL (prettier)
 ;; - Haskell (brittany, hindent, stylish-haskell)
 ;; - HTML/XHTML/XML (tidy)
@@ -636,6 +636,12 @@ Consult the existing formatters for examples of BODY."
   (:install
    (macos "brew install go")
    (windows "scoop install go"))
+  (:languages "Go")
+  (:format (format-all--buffer-easy executable)))
+
+(define-format-all-formatter goimports
+  (:executable "goimports")
+  (:install "go get golang.org/x/tools/cmd/goimports")
   (:languages "Go")
   (:format (format-all--buffer-easy executable)))
 


### PR DESCRIPTION
`goimports` is a pretty popular alternative for `gofmt`. It automatically adds/removes import lines along with formatting the code.

https://godoc.org/golang.org/x/tools/cmd/goimports