### PR TITLE
Add nixpkgs-fmt and make it default

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Supported languages
 * **Ledger** ([*ledger-mode*](https://github.com/ledger/ledger-mode))
 * **Lua** ([*lua-fmt*](https://github.com/trixnz/lua-fmt), [*prettier plugin-lua*](https://github.com/prettier/plugin-lua))
 * **Markdown** ([*prettier*](https://prettier.io/))
-* **Nix** ([*nixfmt*](https://github.com/serokell/nixfmt))
+* **Nix** ([*nixpkgs-fmt*](https://github.com/nix-community/nixpkgs-fmt), [*nixfmt*](https://github.com/serokell/nixfmt))
 * **OCaml** ([*ocp-indent*](https://opam.ocaml.org/packages/ocp-indent/))
 * **Perl** ([*perltidy*](http://perltidy.sourceforge.net/))
 * **PHP** ([*prettier plugin-php*](https://github.com/prettier/plugin-php))

--- a/format-all.el
+++ b/format-all.el
@@ -55,7 +55,7 @@
 ;; - Ledger (ledger-mode)
 ;; - Lua (lua-fmt, prettier plugin-lua)
 ;; - Markdown (prettier)
-;; - Nix (nixfmt)
+;; - Nix (nixpkgs-fmt, nixfmt)
 ;; - OCaml (ocp-indent)
 ;; - Perl (perltidy)
 ;; - PHP (prettier plugin-php)
@@ -141,7 +141,7 @@
     ("Literate Haskell" brittany)
     ("Lua" lua-fmt)
     ("Markdown" prettier)
-    ("Nix" nixfmt)
+    ("Nix" nixpkgs-fmt)
     ("OCaml" ocp-indent)
     ("Objective-C" clang-format)
     ("PHP" prettier)
@@ -721,6 +721,12 @@ Consult the existing formatters for examples of BODY."
 (define-format-all-formatter nixfmt
   (:executable "nixfmt")
   (:install "nix-env -f https://github.com/serokell/nixfmt/archive/master.tar.gz -i")
+  (:languages "Nix")
+  (:format (format-all--buffer-easy executable)))
+
+(define-format-all-formatter nixpkgs-fmt
+  (:executable "nixpkgs-fmt")
+  (:install "nix-env -f https://github.com/nix-community/nixpkgs-fmt/archive/master.tar.gz -i")
   (:languages "Nix")
   (:format (format-all--buffer-easy executable)))
 


### PR DESCRIPTION
This commit adds nixpkgs-fmt formatter and makes it default nix formatter. I suggest making it default as it's the standard used by nixpkgs. Everything seems to be working, but feedback is appreciated. 

Thanks for this awesome package! 