### PR TITLE
Add ReScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Supported languages
 * **Python** ([*black*](https://github.com/ambv/black), [*yapf*](https://github.com/google/yapf))
 * **R** ([*styler*](https://github.com/r-lib/styler))
 * **Reason** ([*bsrefmt*](https://github.com/glennsl/bs-refmt))
+* **ReScript** ([*resfmt*](https://pypi.org/project/resfmt/))
 * **Ruby** ([*rufo*](https://github.com/ruby-formatter/rufo))
 * **Rust** ([*rustfmt*](https://github.com/rust-lang-nursery/rustfmt))
 * **Scala** ([*scalafmt*](https://github.com/scalameta/scalafmt))

--- a/format-all.el
+++ b/format-all.el
@@ -154,6 +154,7 @@
     ("Python" black)
     ("R" styler)
     ("Reason" bsrefmt)
+    ("ReScript" resfmt)
     ("Ruby" rufo)
     ("Rust" rustfmt)
     ("Scala" scalafmt)
@@ -795,6 +796,12 @@ Consult the existing formatters for examples of BODY."
   (:install "npm install --global purty")
   (:languages "PureScript")
   (:format (format-all--buffer-easy executable "-")))
+
+(define-format-all-formatter resfmt
+  (:executable "resfmt")
+  (:install "pip install resfmt")
+  (:languages "ReScript")
+  (:format (format-all--buffer-easy executable)))
 
 (define-format-all-formatter rufo
   (:executable "rufo")


### PR DESCRIPTION
This change adds support for ReScript using `bsc -format` through
resfmt.

Depends-On: https://github.com/lassik/emacs-language-id/pull/6