### PR TITLE
Fixing cmake formatter

### DIFF
--- a/format-all.el
+++ b/format-all.el
@@ -637,7 +637,7 @@ Consult the existing formatters for examples of BODY."
   (:executable "cmake-format")
   (:install "pip install cmake-format")
   (:languages "CMake")
-  (:format (format-all--buffer-easy executable "-")))
+  (:format (format-all--buffer-easy executable)))
 
 (define-format-all-formatter crystal
   (:executable "crystal")


### PR DESCRIPTION
The cmake-format command no longer requires a `-` character to indicate that it should expect `stdin`.

Any argument that it receives is interpreted as a file now (thus giving a `no file "-" found` error.