### PR TITLE
Fourmolu support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Supported languages
 * **GLSL** ([*clang-format*](https://clang.llvm.org/docs/ClangFormat.html))
 * **Go** ([*gofmt*](https://golang.org/cmd/gofmt/), [*goimports*](https://godoc.org/golang.org/x/tools/cmd/goimports))
 * **GraphQL** ([*prettier*](https://prettier.io/))
-* **Haskell** ([*brittany*](https://github.com/lspitzner/brittany), [*hindent*](https://github.com/commercialhaskell/hindent), [*ormolu*](https://github.com/tweag/ormolu), [*stylish-haskell*](https://github.com/jaspervdj/stylish-haskell))
+* **Haskell** ([*brittany*](https://github.com/lspitzner/brittany), [*fourmolu*](https://github.com/fourmolu/fourmolu) [*hindent*](https://github.com/commercialhaskell/hindent), [*ormolu*](https://github.com/tweag/ormolu), [*stylish-haskell*](https://github.com/jaspervdj/stylish-haskell))
 * **HTML/XHTML/XML** ([*tidy*](http://www.html-tidy.org/))
 * **Java** ([*clang-format*](https://clang.llvm.org/docs/ClangFormat.html), [*astyle*](http://astyle.sourceforge.net/))
 * **JavaScript/JSON/JSX** ([*prettier*](https://prettier.io/), [*standard*](https://standardjs.com/))

--- a/format-all.el
+++ b/format-all.el
@@ -708,6 +708,12 @@ Consult the existing formatters for examples of BODY."
   (:languages "Fish")
   (:format (format-all--buffer-easy executable)))
 
+(define-format-all-formatter fourmolu
+  (:executable "fourmolu")
+  (:install "stack install fourmolu")
+  (:languages "Haskell" "Literate Haskell")
+  (:format (format-all--buffer-easy executable)))
+
 (define-format-all-formatter fprettify
   (:executable "fprettify")
   (:install "pip install fprettify")


### PR DESCRIPTION
Adds support for https://github.com/fourmolu/fourmolu for Haskell code. Not sure why the cabal-fmt commit is here, something strange must have happened when I synced my fork with master. Let me know if you'd like me to clean the history up before merging.