### PR TITLE
Use clang-format for Cuda

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Supported languages
 * **CMake** ([*cmake-format*](https://github.com/cheshirekow/cmake_format))
 * **Crystal** ([*crystal tool format*](http://www.motion-express.com/blog/crystal-code-formatter))
 * **CSS/Less/SCSS** ([*prettier*](https://prettier.io/))
+* **Cuda** ([*clang-format*](https://clang.llvm.org/docs/ClangFormat.html))
 * **D** ([*dfmt*](https://github.com/dlang-community/dfmt))
 * **Dart** ([*dartfmt*](https://github.com/dart-lang/dart_style))
 * **Dhall** ([*dhall format*](https://github.com/dhall-lang/dhall-lang))

--- a/format-all.el
+++ b/format-all.el
@@ -35,6 +35,7 @@
 ;; - CMake (cmake-format)
 ;; - Crystal (crystal tool format)
 ;; - CSS/Less/SCSS (prettier)
+;; - Cuda (clang-format)
 ;; - D (dfmt)
 ;; - Dart (dartfmt)
 ;; - Dhall (dhall format)
@@ -125,6 +126,7 @@
     ("CMake" cmake-format)
     ("Crystal" crystal)
     ("CSS" prettier)
+    ("Cuda" clang-format)
     ("D" dfmt)
     ("Dart" dartfmt)
     ("Dhall" dhall)
@@ -677,7 +679,7 @@ Consult the existing formatters for examples of BODY."
   (:install
    (macos "brew install clang-format")
    (windows "scoop install llvm"))
-  (:languages "C" "C#" "C++" "GLSL" "Java" "Objective-C" "Protocol Buffer")
+  (:languages "C" "C#" "C++" "Cuda" "GLSL" "Java" "Objective-C" "Protocol Buffer")
   (:features region)
   (:format
    (format-all--buffer-easy

--- a/format-all.el
+++ b/format-all.el
@@ -690,6 +690,7 @@ Consult the existing formatters for examples of BODY."
                     '(("C"               . ".c")
                       ("C#"              . ".cs")
                       ("C++"             . ".cpp")
+                      ("Cuda"            . ".cu")
                       ("GLSL"            . ".glsl")
                       ("Java"            . ".java")
                       ("Objective-C"     . ".m")


### PR DESCRIPTION
This will work properly when language-id-buffer correctly identifies Cuda. I have a separate PR on your other repo adding support for Cuda there