### PR TITLE
Mute "NESTED_EMPHASIS" warning in html-tidy

### DIFF
--- a/format-all.el
+++ b/format-all.el
@@ -874,6 +874,7 @@ Consult the existing formatters for examples of BODY."
     executable
     "-q"
     "--tidy-mark" "no"
+    "--mute" "NESTED_EMPHASIS"
     "-indent"
     (when (equal language "XML") "-xml"))))
 


### PR DESCRIPTION
Mute annoying warning splash window for nested_emphasis in html-tidy