### PR TITLE
Add --stderr to StandardRB formatter command

### DIFF
--- a/format-all.el
+++ b/format-all.el
@@ -1138,6 +1138,7 @@ Consult the existing formatters for examples of BODY."
    (format-all--buffer-hard-ruby
     "standard" '(0 1) nil nil
     executable
+    "--stderr"
     "--fix"
     "--stdin" (or (buffer-file-name) (buffer-name)))))
 


### PR DESCRIPTION
Without this, Rubocop (which is what StandardRB uses under the hood)
outputs everything to stdout, including a line of several "="
characters. StandardRB is smart enough to filter a majority of this
output, but not that line of "=" characters, which then makes its way to
the formatted file in emacs' buffer. This fixe the issue.

Closes issue #156.