### PR TITLE
Add `dart format` as a formatter for dart

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Supported languages
 * **CSS/Less/SCSS** ([*prettier*](https://prettier.io/))
 * **Cuda** ([*clang-format*](https://clang.llvm.org/docs/ClangFormat.html))
 * **D** ([*dfmt*](https://github.com/dlang-community/dfmt))
-* **Dart** ([*dartfmt*](https://github.com/dart-lang/dart_style))
+* **Dart** ([*dartfmt*](https://github.com/dart-lang/dart_style), [*dart-format*](https://dart.dev/tools/dart-format))
 * **Dhall** ([*dhall format*](https://github.com/dhall-lang/dhall-lang))
 * **Dockerfile** ([*dockfmt*](https://github.com/jessfraz/dockfmt))
 * **Elixir** ([*mix format*](https://hexdocs.pm/mix/master/Mix.Tasks.Format.html))

--- a/format-all.el
+++ b/format-all.el
@@ -37,7 +37,7 @@
 ;; - CSS/Less/SCSS (prettier)
 ;; - Cuda (clang-format)
 ;; - D (dfmt)
-;; - Dart (dartfmt)
+;; - Dart (dartfmt, dart-format)
 ;; - Dhall (dhall format)
 ;; - Dockerfile (dockfmt)
 ;; - Elixir (mix format)
@@ -129,7 +129,7 @@
     ("CSS" prettier)
     ("Cuda" clang-format)
     ("D" dfmt)
-    ("Dart" dartfmt)
+    ("Dart" dart-format)
     ("Dhall" dhall)
     ("Dockerfile" dockfmt)
     ("Elixir" mix-format)
@@ -735,6 +735,14 @@ Consult the existing formatters for examples of BODY."
     executable
     (when (buffer-file-name)
       (list "--stdin-name" (buffer-file-name))))))
+
+(define-format-all-formatter dart-format
+  (:executable "dart")
+  (:install (macos "brew tap dart-lang/dart && brew install dart"))
+  (:languages "Dart")
+  (:features)
+  (:format
+   (format-all--buffer-easy executable "format" "--output" "show")))
 
 (define-format-all-formatter dfmt
   (:executable "dfmt")


### PR DESCRIPTION
I have not changed the default to the new one, let me know if that should be done. 

For anyone else running into this, you can change the formatter using: 

```emacs-lisp
(setq-default format-all-formatters '(("Dart" dart-format)))
```

ref: https://github.com/lassik/emacs-format-all-the-code/issues/130