### PR TITLE
get R user environment

### DIFF
--- a/format-all.el
+++ b/format-all.el
@@ -1165,7 +1165,7 @@ Consult the existing formatters for examples of BODY."
   (:features)
   (:format
    (format-all--buffer-easy
-    executable "--vanilla"
+    executable
     "-e" (concat
           "options(styler.colored_print.vertical=FALSE);"
           " con <- file('stdin');"


### PR DESCRIPTION
As stated in the R manual[1], the flag `--vanilla` stands for --no-site-file,
--no-init-file, --no-environ and (except for R CMD) --no-restore.
In sum, no user environment can be loaded using that flag, as reported here[2].
When removed, the command `format-all-buffer` works as expected in the ess-mode.

[1]: https://stat.ethz.ch/R-manual/R-devel/library/base/html/Startup.html

[2]: https://github.com/lassik/emacs-format-all-the-code/issues/76#issuecomment-591465281

Related to #76