### PR TITLE
Add Clojure formatter `zprint`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Supported languages
 * **C/C++/Objective-C** ([*clang-format*](https://clang.llvm.org/docs/ClangFormat.html), [*astyle*](http://astyle.sourceforge.net/))
 * **C#** ([*clang-format*](https://clang.llvm.org/docs/ClangFormat.html), [*astyle*](http://astyle.sourceforge.net/))
 * **Cabal** ([*cabal-fmt*](https://github.com/phadej/cabal-fmt))
-* **Clojure/ClojureScript** ([*node-cljfmt*](https://github.com/snoe/node-cljfmt))
+* **Clojure/ClojureScript** ([*node-cljfmt*](https://github.com/snoe/node-cljfmt), [*zprint*](https://github.com/kkinnear/zprint))
 * **CMake** ([*cmake-format*](https://github.com/cheshirekow/cmake_format))
 * **Crystal** ([*crystal tool format*](http://www.motion-express.com/blog/crystal-code-formatter))
 * **CSS/Less/SCSS** ([*prettier*](https://prettier.io/))

--- a/format-all.el
+++ b/format-all.el
@@ -31,7 +31,7 @@
 ;; - C/C++/Objective-C (clang-format, astyle)
 ;; - C# (clang-format, astyle)
 ;; - Cabal (cabal-fmt)
-;; - Clojure/ClojureScript (node-cljfmt)
+;; - Clojure/ClojureScript (node-cljfmt, zprint)
 ;; - CMake (cmake-format)
 ;; - Crystal (crystal tool format)
 ;; - CSS/Less/SCSS (prettier)
@@ -710,6 +710,13 @@ Consult the existing formatters for examples of BODY."
 (define-format-all-formatter cljfmt
   (:executable "cljfmt")
   (:install "npm install --global node-cljfmt")
+  (:languages "Clojure")
+  (:features)
+  (:format (format-all--buffer-easy executable)))
+
+(define-format-all-formatter zprint
+  (:executable "zprint")
+  (:install)
   (:languages "Clojure")
   (:features)
   (:format (format-all--buffer-easy executable)))


### PR DESCRIPTION
The currently supported [node-cljfmt](https://github.com/snoe/node-cljfmt) has been recently deprecated, so I added support for the competing project [zprint](https://github.com/kkinnear/zprint). I haven't changed the default, but I think zprint deserves to be the default since it supports [Babashka](https://babashka.org/) scripts and is more configurable.

Let me know what you think :)