### PR TITLE
fix: rely on prettier to choose the correct parser

### DIFF
--- a/format-all.el
+++ b/format-all.el
@@ -1006,14 +1006,6 @@ Consult the existing formatters for examples of BODY."
   (:format
    (format-all--buffer-easy
     executable
-    "--parser" (let ((pair (assoc language
-                                  '(("_Angular"   . "angular")
-                                    ("_Flow"      . "flow")
-                                    ("JavaScript" . "babel")
-                                    ("JSX"        . "babel")
-                                    ("Solidity"   . "solidity-parse")
-                                    ("TSX"        . "typescript")))))
-                 (if pair (cdr pair) (downcase language)))
     (when (buffer-file-name) (list "--stdin-filepath" (buffer-file-name)))
     (let ((ignore-file (format-all--locate-file ".prettierignore")))
       (when ignore-file (list "--ignore-path" ignore-file)))


### PR DESCRIPTION
According to the prettier [documentation](https://prettier.io/docs/en/options.html#parser).

> Prettier automatically infers the parser from the input file path, so you shouldn’t have to change this setting.

If someone didn't set up their prettierrc file, then format-all should rely on prettier to choose the correct parser. They still get formatting for free (if prettier is installed). 
If they need a specific kind of parser, they should override them by using a prettier config file.