### PR TITLE
Add missing features field to Zig formatter

### DIFF
--- a/format-all.el
+++ b/format-all.el
@@ -1259,6 +1259,7 @@ Consult the existing formatters for examples of BODY."
   (:executable "zig")
   (:install)
   (:languages "Zig")
+  (:features)
   (:format (format-all--buffer-easy executable "fmt" "--stdin")))
 
 (define-format-all-formatter zprint


### PR DESCRIPTION
There seems to be an assert for this field to exist, and so evaluating the file doesn't work without this.