### PR TITLE
Add efmt (an Erlang formatter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Supported languages
 * **Elixir** ([*mix format*](https://hexdocs.pm/mix/master/Mix.Tasks.Format.html))
 * **Elm** ([*elm-format*](https://github.com/avh4/elm-format))
 * **Emacs Lisp** (Emacs)
+* **Erlang** ([*efmt*](https://github.com/sile/efmt))
 * **F#** ([*fantomas*](https://github.com/fsprojects/fantomas))
 * **Fish Shell** ([*fish_indent*](https://fishshell.com/docs/current/commands.html#fish_indent))
 * **Fortran Free Form** ([*fprettify*](https://github.com/pseewald/fprettify))

--- a/format-all.el
+++ b/format-all.el
@@ -43,6 +43,7 @@
 ;; - Elixir (mix format)
 ;; - Elm (elm-format)
 ;; - Emacs Lisp (Emacs)
+;; - Erlang (efmt)
 ;; - F# (fantomas)
 ;; - Fish Shell (fish_indent)
 ;; - Fortran Free Form (fprettify)
@@ -138,6 +139,7 @@
     ("Elixir" mix-format)
     ("Elm" elm-format)
     ("Emacs Lisp" emacs-lisp)
+    ("Erlang" efmt)
     ("F#" fantomas)
     ("Fish" fish-indent)
     ("Fortran Free Form" fprettify)
@@ -955,6 +957,13 @@ Consult the existing formatters for examples of BODY."
     (let ((config-file (format-all--locate-file ".formatter.exs")))
       (when config-file (list "--dot-formatter" config-file)))
     "-")))
+
+(define-format-all-formatter efmt
+  (:executable "efmt")
+  (:install "cargo install efmt")
+  (:languages "Erlang")
+  (:features)
+  (:format (format-all--buffer-easy executable "-")))
 
 (define-format-all-formatter nginxfmt
   (:executable "nginxfmt")

--- a/format-all.el
+++ b/format-all.el
@@ -775,6 +775,13 @@ Consult the existing formatters for examples of BODY."
   (:features)
   (:format (format-all--buffer-easy executable "fmt")))
 
+(define-format-all-formatter efmt
+  (:executable "efmt")
+  (:install "cargo install efmt")
+  (:languages "Erlang")
+  (:features)
+  (:format (format-all--buffer-easy executable "-")))
+
 (define-format-all-formatter elm-format
   (:executable "elm-format")
   (:install (macos "brew install elm"))
@@ -957,13 +964,6 @@ Consult the existing formatters for examples of BODY."
     (let ((config-file (format-all--locate-file ".formatter.exs")))
       (when config-file (list "--dot-formatter" config-file)))
     "-")))
-
-(define-format-all-formatter efmt
-  (:executable "efmt")
-  (:install "cargo install efmt")
-  (:languages "Erlang")
-  (:features)
-  (:format (format-all--buffer-easy executable "-")))
 
 (define-format-all-formatter nginxfmt
   (:executable "nginxfmt")


### PR DESCRIPTION
Hi, thank you for creating this useful package.

I'd like to add Erlang support to this package.
This PR adds [efmt](https://github.com/sile/efmt) as the formatter for Erlang code (BTW, I'm the author of this formatter).
However, `efmt` is not a famous Erlang formatter. So I'm willing to close this PR if you want to avoid using such a formatter.

Related PR: https://github.com/lassik/emacs-language-id/pull/15