### PR TITLE
fix: let prettier select parser automatically only when it succeeds

### DIFF
--- a/format-all.el
+++ b/format-all.el
@@ -1027,7 +1027,8 @@ Consult the existing formatters for examples of BODY."
   (:format
    (format-all--buffer-easy
     executable
-    (unless (buffer-file-name)
+    (unless (and (buffer-file-name)
+                 (= 0 (call-process "prettier" (buffer-file-name))))
       (list "--parser"
             (let ((pair (assoc language
                                '(("_Angular"   . "angular")


### PR DESCRIPTION
@lassik  https://github.com/lassik/emacs-format-all-the-code/issues/175#issuecomment-1153433796 solved.