### PR TITLE
Add erb formatter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Supported languages
 * **Elixir** ([*mix format*](https://hexdocs.pm/mix/master/Mix.Tasks.Format.html))
 * **Elm** ([*elm-format*](https://github.com/avh4/elm-format))
 * **Emacs Lisp** (Emacs)
+* **Erb** ([*erb-format*](https://github.com/nebulab/erb-formatter))
 * **Erlang** ([*efmt*](https://github.com/sile/efmt))
 * **F#** ([*fantomas*](https://github.com/fsprojects/fantomas))
 * **Fish Shell** ([*fish_indent*](https://fishshell.com/docs/current/commands.html#fish_indent))

--- a/format-all.el
+++ b/format-all.el
@@ -43,6 +43,7 @@
 ;; - Elixir (mix format)
 ;; - Elm (elm-format)
 ;; - Emacs Lisp (Emacs)
+;; - Erb (erb-format)
 ;; - Erlang (efmt)
 ;; - F# (fantomas)
 ;; - Fish Shell (fish_indent)
@@ -148,6 +149,7 @@
     ("GraphQL" prettier)
     ("Haskell" brittany)
     ("HTML" html-tidy)
+    ("HTML+ERB" erb-format)
     ("Java" clang-format)
     ("JavaScript" prettier)
     ("JSON" prettier)
@@ -819,6 +821,13 @@ Consult the existing formatters for examples of BODY."
     (if region
         (lambda () (indent-region (car region) (cdr region)))
         (lambda () (indent-region (point-min) (point-max)))))))
+
+(define-format-all-formatter erb-format
+  (:executable "erb-format")
+  (:install "gem install erb-formatter")
+  (:languages "HTML+ERB")
+  (:features)
+  (:format (format-all--buffer-easy executable "--stdin")))
 
 (define-format-all-formatter fantomas
   (:executable "fantomas")


### PR DESCRIPTION
Couldn't find any guidelines to contributing so my apologies if something is not handled properly.

- Added matcher to match files ending in `.erb` to the `_Erb` language (which was unsupported before).
- Adds support for [erb-formatter](https://github.com/nebulab/erb-formatter) to format `_Erb` files.

I decided to use `_Erb` as the language-id as Github does not seem to have an official title for the language, instead identifying it as `HTML+ERB`.