### PR TITLE
Try add mint-lang support.

### DIFF
--- a/format-all.el
+++ b/format-all.el
@@ -163,6 +163,7 @@
     ("Literate Haskell" brittany)
     ("Lua" lua-fmt)
     ("Markdown" prettier)
+    ("Mint" mint)
     ("Nix" nixpkgs-fmt)
     ("Objective-C" clang-format)
     ("OCaml" ocp-indent)
@@ -744,6 +745,13 @@ Consult the existing formatters for examples of BODY."
   (:features)
   (:format (format-all--buffer-easy executable "tool" "format" "-")))
 
+(define-format-all-formatter mint
+  (:executable "mint")
+  (:install (macos "brew install mint-lang"))
+  (:languages "Mint")
+  (:features)
+  (:format (format-all--buffer-easy executable "format" "--stdin")))
+
 (define-format-all-formatter dart-format
   (:executable "dart")
   (:install (macos "brew tap dart-lang/dart && brew install dart"))
@@ -828,7 +836,7 @@ Consult the existing formatters for examples of BODY."
     'emacs-lisp-mode
     (if region
         (lambda () (indent-region (car region) (cdr region)))
-        (lambda () (indent-region (point-min) (point-max)))))))
+      (lambda () (indent-region (point-min) (point-max)))))))
 
 (define-format-all-formatter erb-format
   (:executable "erb-format")
@@ -1106,7 +1114,7 @@ Consult the existing formatters for examples of BODY."
    (format-all--buffer-easy
     executable "format" "-stdin"
     (let ((ext (if (not (buffer-file-name)) ""
-                   (file-name-extension (buffer-file-name)))))
+                 (file-name-extension (buffer-file-name)))))
       (concat "." (if (equal ext "") "res" ext))))))
 
 (define-format-all-formatter rubocop
@@ -1567,7 +1575,7 @@ The PROMPT argument works as for `format-all-buffer'."
    (let ((prompt (if current-prefix-arg 'always t)))
      (if (use-region-p)
          (list (region-beginning) (region-end) prompt)
-         (error "The region is not active now"))))
+       (error "The region is not active now"))))
   (format-all--buffer-or-region prompt (cons start end)))
 
 (defun format-all-ensure-formatter ()


### PR DESCRIPTION
https://github.com/lassik/emacs-format-all-the-code/issues/198

Hi, current this PR still not work, when i try to run `format-all-buffer` in one mint buffer, i get error like this:

```
Unhandled exception: Error opening file with mode 'r': '/home/common/Study/Mint/test_formatter/source/mint.json': No such file or directory (File::NotFoundError)
  from ???
  from ???
  from ???
  from ???
  from ???
  from ???
  from ???
  from ???
  from src/env/__libc_start_main.c:94:2 in 'libc_start_main_stage2'
```

I am still newbie to both of `emacs-format-all-the-code` and `mint`, i don't know why this happen.

But, i can confirm following code can output the correct formatted buffer content:

```
 ╭─ 20:27  zw963 ⮀ ~/Study/Mint/test_formatter ⮀ ⭠ (30f376c) master  ➦ ruby-3.1.0 
 ╰─ $ cat source/Main.mint |mint format --stdin
component Main {
  style app {
    justify-content: center;
    flex-direction: column;
    align-items: center;
    display: flex;

    background-color: #282C34;
    height: 100vh;
    width: 100vw;

    font-family: Open Sans;
    font-weight: bold;
  }

  fun render : Html {
    <div::app>
      <Logo/>

      <Info mainPath="source/Main.mint"/>

      <Link href="https://www.mint-lang.com/">
        "Learn Mint"
      </Link>
    </div>
  }
}
```

