### PR TITLE
Support fourmolu version 0.8

### DIFF
--- a/format-all.el
+++ b/format-all.el
@@ -856,7 +856,7 @@ Consult the existing formatters for examples of BODY."
   (:install "stack install fourmolu")
   (:languages "Haskell" "Literate Haskell")
   (:features)
-  (:format (format-all--buffer-easy executable)))
+  (:format (format-all--buffer-easy executable "--stdin-input-file" (buffer-file-name))))
 
 (define-format-all-formatter fprettify
   (:executable "fprettify")


### PR DESCRIPTION
This change enables using the latest formater version by fixing
this error:
  The --stdin-input-file option is necessary when using input
  from stdin and accounting for .cabal files