### PR TITLE
function to reset format-all-formatters locally for current buffer

### DIFF
--- a/format-all.el
+++ b/format-all.el
@@ -1588,6 +1588,11 @@ The PROMPT argument works as for `format-all-buffer'."
          (error "The region is not active now"))))
   (format-all--buffer-or-region prompt (cons start end)))
 
+(defun format-all-reset-local-formatters ()
+  "Reset format-all-formatters locally for the current buffer."
+  (interactive)
+  (setq-local format-all-formatters nil))
+
 (defun format-all-ensure-formatter ()
   "Ensure current buffer has a formatter, using default if not."
   (interactive)


### PR DESCRIPTION
Hi,

I implemented a simple function `format-all-reset-local-formatters` to allow users to reset the current `format-all-formatters` list for the current buffer.

This is useful in the case a buffer mode has 2 or more formarters, for example JSON has 2 formatters `pretitter` and `prettierd`. When users want to switch from one formatter to the other formatter, they just need to call this function to reset `format-all-formatters`. The next time they format the buffer, `format-all` will ask which formatter they want to use.

Can you take a look and merge it if it's useful?

Thanks!