### PR TITLE
Pass `--keywords upper --reindent` to sqlformat(1)

### DIFF
--- a/format-all.el
+++ b/format-all.el
@@ -1210,7 +1210,7 @@ Consult the existing formatters for examples of BODY."
                                  'utf-8)))
           (process-environment (cons (concat "PYTHONIOENCODING=" oenc)
                                      process-environment)))
-     (format-all--buffer-easy executable "--encoding" ienc "-"))))
+     (format-all--buffer-easy executable "--keywords" "upper" "--reindent" "--encoding" ienc "-"))))
 
 (define-format-all-formatter standard
   (:executable "standard")


### PR DESCRIPTION
With no options, sqlformat(1) does not seem to change anything.  `--keywords upper` is a matter of taste, but I believe it's a pretty common formatting style for SQL.