### PR TITLE
Add autoload for format-all-ensure-formatter

### DIFF
--- a/format-all.el
+++ b/format-all.el
@@ -1600,6 +1600,7 @@ The PROMPT argument works as for `format-all-buffer'."
          (error "The region is not active now"))))
   (format-all--buffer-or-region prompt (cons start end)))
 
+;;;###autoload
 (defun format-all-ensure-formatter ()
   "Ensure current buffer has a formatter, using default if not."
   (interactive)


### PR DESCRIPTION
It is often called before calling format-all-mode, so it'd be nice if autoloading covered it.