### PR TITLE
Add support for HTML+EEX

### DIFF
--- a/format-all.el
+++ b/format-all.el
@@ -151,6 +151,7 @@
     ("Haskell" brittany)
     ("HTML" html-tidy)
     ("HTML+ERB" erb-format)
+    ("HTML+EEX" mix-format)
     ("Java" clang-format)
     ("JavaScript" prettier)
     ("JSON" prettier)
@@ -982,7 +983,7 @@ Consult the existing formatters for examples of BODY."
 (define-format-all-formatter mix-format
   (:executable "mix")
   (:install (macos "brew install elixir"))
-  (:languages "Elixir")
+  (:languages "Elixir" "HTML+EEX")
   (:features)
   (:format
    (format-all--buffer-hard
@@ -991,6 +992,8 @@ Consult the existing formatters for examples of BODY."
     "format"
     (let ((config-file (format-all--locate-file ".formatter.exs")))
       (when config-file (list "--dot-formatter" config-file)))
+    "--stdin-filename"
+    (buffer-file-name)
     "-")))
 
 (define-format-all-formatter nginxfmt

--- a/format-all.el
+++ b/format-all.el
@@ -150,8 +150,8 @@
     ("GraphQL" prettier)
     ("Haskell" brittany)
     ("HTML" html-tidy)
-    ("HTML+ERB" erb-format)
     ("HTML+EEX" mix-format)
+    ("HTML+ERB" erb-format)
     ("Java" clang-format)
     ("JavaScript" prettier)
     ("JSON" prettier)
@@ -992,9 +992,12 @@ Consult the existing formatters for examples of BODY."
     "format"
     (let ((config-file (format-all--locate-file ".formatter.exs")))
       (when config-file (list "--dot-formatter" config-file)))
-    "--stdin-filename"
-    (buffer-file-name)
-    "-")))
+    (cond ((buffer-file-name)
+       (list "--stdin-filename" (buffer-file-name) "-"))
+      ((equal language "HTML+EEX")
+       (list "--stdin-filename" "stdin.heex" "-"))
+      (t
+       (list))))))
 
 (define-format-all-formatter nginxfmt
   (:executable "nginxfmt")


### PR DESCRIPTION
`--stdin-filename` is necessary for HEEX and should not make a difference for other Elixir files, ref:
https://hexdocs.pm/mix/1.14.1/Mix.Tasks.Format.html
Requires at least Elixir 1.14.0 and for HEEX templates the correct `.formatter.exs` configuration: https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.HTMLFormatter.html#module-setup

goes along: https://github.com/lassik/emacs-language-id/pull/23