### PR TITLE
fix (kotlin linter): remove log files from output

### DIFF
--- a/format-all.el
+++ b/format-all.el
@@ -955,7 +955,7 @@ Consult the existing formatters for examples of BODY."
   (:install (macos "brew install ktlint"))
   (:languages "Kotlin")
   (:features)
-  (:format (format-all--buffer-easy executable "--format" "--stdin")))
+  (:format (format-all--buffer-easy executable "--log-level=none" "--format" "--stdin")))
 
 (define-format-all-formatter latexindent
   (:executable "latexindent")


### PR DESCRIPTION
`ktlint` now prints info logs by default, we have to disable logging when using the formatter.

sadly the new cli arg for disabling logging has not been released yet, so I'll leave this in _draft_ until it has.