### PR TITLE
Adding csharpier to format-all

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Supported languages
 * **Bazel Starlark** ([*buildifier*](https://github.com/bazelbuild/buildtools/tree/master/buildifier))
 * **BibTeX** (Emacs)
 * **C/C++/Objective-C** ([*clang-format*](https://clang.llvm.org/docs/ClangFormat.html), [*astyle*](http://astyle.sourceforge.net/))
-* **C#** ([*clang-format*](https://clang.llvm.org/docs/ClangFormat.html), [*astyle*](http://astyle.sourceforge.net/))
+* **C#** ([*clang-format*](https://clang.llvm.org/docs/ClangFormat.html), [*astyle*](http://astyle.sourceforge.net/), [*csharpier*](https://github.com/belav/csharpier))
 * **Cabal** ([*cabal-fmt*](https://github.com/phadej/cabal-fmt))
 * **Caddyfile** ([*caddy-fmt*](https://caddyserver.com/docs/command-line#caddy-fmt))
 * **Clojure/ClojureScript** ([*zprint*](https://github.com/kkinnear/zprint), [*node-cljfmt*](https://github.com/snoe/node-cljfmt))

--- a/format-all.el
+++ b/format-all.el
@@ -127,7 +127,7 @@
     ("Bazel" buildifier)
     ("BibTeX" emacs-bibtex)
     ("C" clang-format)
-    ("C#" dotnet-csharpier)
+    ("C#" csharpier)
     ("C++" clang-format)
     ("Cabal Config" cabal-fmt)
     ("Clojure" zprint)
@@ -830,13 +830,12 @@ Consult the existing formatters for examples of BODY."
   (:features)
   (:format (format-all--buffer-easy executable "fmt")))
 
-(define-format-all-formatter dotnet-csharpier
+(define-format-all-formatter csharpier
   (:executable "dotnet-csharpier")
   (:install "dotnet install -g csharpier")
   (:languages "C#")
   (:features)
   (:format (format-all--buffer-easy executable "--write-stdout")))
-
 (define-format-all-formatter efmt
   (:executable "efmt")
   (:install "cargo install efmt")

--- a/format-all.el
+++ b/format-all.el
@@ -768,6 +768,13 @@ Consult the existing formatters for examples of BODY."
   (:features)
   (:format (format-all--buffer-easy executable "tool" "format" "-")))
 
+(define-format-all-formatter csharpier
+  (:executable "dotnet-csharpier")
+  (:install "dotnet install -g csharpier")
+  (:languages "C#")
+  (:features)
+  (:format (format-all--buffer-easy executable "--write-stdout")))
+
 (define-format-all-formatter dart-format
   (:executable "dart")
   (:install (macos "brew tap dart-lang/dart && brew install dart"))
@@ -830,12 +837,6 @@ Consult the existing formatters for examples of BODY."
   (:features)
   (:format (format-all--buffer-easy executable "fmt")))
 
-(define-format-all-formatter csharpier
-  (:executable "dotnet-csharpier")
-  (:install "dotnet install -g csharpier")
-  (:languages "C#")
-  (:features)
-  (:format (format-all--buffer-easy executable "--write-stdout")))
 (define-format-all-formatter efmt
   (:executable "efmt")
   (:install "cargo install efmt")

--- a/format-all.el
+++ b/format-all.el
@@ -29,7 +29,7 @@
 ;; - Bazel Starlark (buildifier)
 ;; - BibTeX (Emacs)
 ;; - C/C++/Objective-C (clang-format, astyle)
-;; - C# (clang-format, astyle)
+;; - C# (clang-format, astyle, csharpier)
 ;; - Cabal (cabal-fmt)
 ;; - Caddyfile (caddy fmt)
 ;; - Clojure/ClojureScript (zprint, node-cljfmt)
@@ -127,7 +127,7 @@
     ("Bazel" buildifier)
     ("BibTeX" emacs-bibtex)
     ("C" clang-format)
-    ("C#" clang-format)
+    ("C#" dotnet-csharpier)
     ("C++" clang-format)
     ("Cabal Config" cabal-fmt)
     ("Clojure" zprint)
@@ -829,6 +829,13 @@ Consult the existing formatters for examples of BODY."
   (:languages "Dockerfile")
   (:features)
   (:format (format-all--buffer-easy executable "fmt")))
+
+(define-format-all-formatter dotnet-csharpier
+  (:executable "dotnet-csharpier")
+  (:install "dotnet install -g csharpier")
+  (:languages "C#")
+  (:features)
+  (:format (format-all--buffer-easy executable "--write-stdout")))
 
 (define-format-all-formatter efmt
   (:executable "efmt")


### PR DESCRIPTION
Adding this [csharpier](https://github.com/belav/csharpier) as the default formatter for C# files.  