### PR TITLE
Add syntax_tree formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Supported languages
 * **Racket** ([*raco fmt*](https://docs.racket-lang.org/fmt/))
 * **Reason** ([*bsrefmt*](https://github.com/glennsl/bs-refmt))
 * **ReScript** ([*rescript format*](https://www.npmjs.com/package/rescript))
-* **Ruby** ([*rubocop*](https://github.com/rubocop/rubocop), [*rufo*](https://github.com/ruby-formatter/rufo), [*standardrb*](https://github.com/testdouble/standard), [*syntax_tree*](https://github.com/ruby-syntax-tree/syntax_tree))
+* **Ruby** ([*rubocop*](https://github.com/rubocop/rubocop), [*rufo*](https://github.com/ruby-formatter/rufo), [*standardrb*](https://github.com/testdouble/standard), [*stree (syntax_tree)*](https://github.com/ruby-syntax-tree/syntax_tree))
 * **Rust** ([*rustfmt*](https://github.com/rust-lang-nursery/rustfmt))
 * **Scala** ([*scalafmt*](https://github.com/scalameta/scalafmt))
 * **Shell script** ([*beautysh*](https://github.com/lovesegfault/beautysh), [*shfmt*](https://github.com/mvdan/sh))

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Supported languages
 * **Racket** ([*raco fmt*](https://docs.racket-lang.org/fmt/))
 * **Reason** ([*bsrefmt*](https://github.com/glennsl/bs-refmt))
 * **ReScript** ([*rescript format*](https://www.npmjs.com/package/rescript))
-* **Ruby** ([*rubocop*](https://github.com/rubocop/rubocop), [*rufo*](https://github.com/ruby-formatter/rufo), [*standardrb*](https://github.com/testdouble/standard))
+* **Ruby** ([*rubocop*](https://github.com/rubocop/rubocop), [*rufo*](https://github.com/ruby-formatter/rufo), [*standardrb*](https://github.com/testdouble/standard), [*syntax_tree*](https://github.com/ruby-syntax-tree/syntax_tree))
 * **Rust** ([*rustfmt*](https://github.com/rust-lang-nursery/rustfmt))
 * **Scala** ([*scalafmt*](https://github.com/scalameta/scalafmt))
 * **Shell script** ([*beautysh*](https://github.com/lovesegfault/beautysh), [*shfmt*](https://github.com/mvdan/sh))

--- a/format-all.el
+++ b/format-all.el
@@ -1365,7 +1365,7 @@ Consult the existing formatters for examples of BODY."
     "stree" '(0 1) nil '(".streerc")
     executable
     "format"
-    (or (buffer-file-name) (buffer-name)))))
+    )))
 
 (define-format-all-formatter taplo-fmt
   (:executable "taplo")

--- a/format-all.el
+++ b/format-all.el
@@ -75,7 +75,7 @@
 ;; - Racket (raco-fmt)
 ;; - Reason (bsrefmt)
 ;; - ReScript (rescript)
-;; - Ruby (rubocop, rufo, standardrb, syntax-tree)
+;; - Ruby (rubocop, rufo, standardrb, stree)
 ;; - Rust (rustfmt)
 ;; - Scala (scalafmt)
 ;; - Shell script (beautysh, shfmt)
@@ -1355,14 +1355,14 @@ Consult the existing formatters for examples of BODY."
                                   (line-number-at-pos (car region))
                                   (line-number-at-pos (cdr region))))))))
 
-(define-format-all-formatter syntax_tree
+(define-format-all-formatter stree
   (:executable "stree")
   (:install "gem install syntax_tree:'>=2.0.1'")
   (:languages "Ruby")
   (:features)
   (:format
    (format-all--buffer-hard-ruby
-    "syntax_tree" '(0 1) nil '(".streerc")
+    "stree" '(0 1) nil '(".streerc")
     executable
     "format"
     (or (buffer-file-name) (buffer-name)))))

--- a/format-all.el
+++ b/format-all.el
@@ -75,7 +75,7 @@
 ;; - Racket (raco-fmt)
 ;; - Reason (bsrefmt)
 ;; - ReScript (rescript)
-;; - Ruby (rubocop, rufo, standardrb)
+;; - Ruby (rubocop, rufo, standardrb, syntax-tree)
 ;; - Rust (rustfmt)
 ;; - Scala (scalafmt)
 ;; - Shell script (beautysh, shfmt)

--- a/format-all.el
+++ b/format-all.el
@@ -1355,6 +1355,18 @@ Consult the existing formatters for examples of BODY."
                                   (line-number-at-pos (car region))
                                   (line-number-at-pos (cdr region))))))))
 
+(define-format-all-formatter syntax_tree
+  (:executable "stree")
+  (:install "gem install syntax_tree:'>=2.0.1'")
+  (:languages "Ruby")
+  (:features)
+  (:format
+   (format-all--buffer-hard-ruby
+    "syntax_tree" '(0 1) nil '(".streerc")
+    executable
+    "format"
+    (or (buffer-file-name) (buffer-name)))))
+
 (define-format-all-formatter taplo-fmt
   (:executable "taplo")
   (:install "npm install --global @taplo/cli")


### PR DESCRIPTION
Add formatting support for [Ruby syntax_tree](https://github.com/ruby-syntax-tree/syntax_tree) using the `stree format` command. 