### PR TITLE
change sql formatter to sql-formatter

### DIFF
--- a/format-all.el
+++ b/format-all.el
@@ -81,7 +81,7 @@
 ;; - Shell script (beautysh, shfmt)
 ;; - Snakemake (snakefmt)
 ;; - Solidity (prettier plugin)
-;; - SQL (pgformatter, sqlformat)
+;; - SQL (pgformatter, sql-formatter)
 ;; - Svelte (prettier plugin)
 ;; - Swift (swiftformat)
 ;; - Terraform (terraform fmt)
@@ -182,7 +182,7 @@
     ("SCSS" prettier)
     ("Shell" shfmt)
     ("Solidity" prettier)
-    ("SQL" sqlformat)
+    ("SQL" sql-formatter)
     ("Svelte" prettier)
     ("Swift" swiftformat)
     ("Terraform" terraform-fmt)
@@ -1266,9 +1266,9 @@ Consult the existing formatters for examples of BODY."
   (:features)
   (:format (format-all--buffer-easy executable "-")))
 
-(define-format-all-formatter sqlformat
-  (:executable "sqlformat")
-  (:install "pip install sqlparse")
+(define-format-all-formatter sql-formatter
+  (:executable "sql-formatter")
+  (:install "npm install -g sql-formatter")
   (:languages "SQL")
   (:features)
   (:format
@@ -1280,7 +1280,7 @@ Consult the existing formatters for examples of BODY."
                                  'utf-8)))
           (process-environment (cons (concat "PYTHONIOENCODING=" oenc)
                                      process-environment)))
-     (format-all--buffer-easy executable "--encoding" ienc "-"))))
+     (format-all--buffer-easy executable))))
 
 (define-format-all-formatter standard
   (:executable "standard")


### PR DESCRIPTION
The default sql formatter sqlformat doesn't work. For example:
```sql
CREATE TABLE student (
sid INT PRIMARY KEY, name VARCHAR(16), login VARCHAR(32) UNIQUE, age SMALLINT, gpa FLOAT );
```
format this piece of sql with
```
sqlformat tmp.sql  --reindent --indent_width 4 --keywords upper --use_space_around_operators
```

gets:
```
CREATE TABLE student (sid INT PRIMARY KEY,
                                      name VARCHAR(16),
                                           login VARCHAR(32) UNIQUE,
                                                             age SMALLINT, gpa FLOAT);
```

Without any options, `sqlformat tmp.sql` just prints the input.

[The comment in the first answer about sqlformat](https://stackoverflow.com/questions/392001/sql-string-formatter) points out the same thing.

While [sql-formatter](https://www.npmjs.com/package/sql-formatter) works great without any options. So I change sqlformat support to sql-formatter.