### PR TITLE
Add format-all-region-or-buffer command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Lets you auto-format source code in many languages using the same
 command for all languages, instead of learning a different Emacs
 package and formatting command for each language.
 
-Just do **M-x** `format-all-buffer` and it will try its best to do the
-right thing. To auto-format code on save, use the minor mode
+Just do **M-x** `format-all-region-or-buffer` and it will try its best
+to do the right thing. To auto-format code on save, use the minor mode
 `format-all-mode`. Please see the documentation for that function for
 instructions.
 

--- a/format-all.el
+++ b/format-all.el
@@ -1654,6 +1654,18 @@ If REGION is non-nil, it is a (START . END) pair passed to the formatter."
     (format-all--run-chain language chain region)))
 
 ;;;###autoload
+(defun format-all-region-or-buffer (&optional prompt)
+  "Auto-format the source code in the current region or buffer.
+In Transient Mark mode when the mark is active, call `format-all-region'.
+Otherwise, call `format-all-buffer'.
+
+The PROMPT argument works as for `format-all-buffer'."
+  (interactive (list (if current-prefix-arg 'always t)))
+  (if (use-region-p)
+      (format-all-region (region-beginning) (region-end) prompt)
+    (format-all-buffer prompt)))
+
+;;;###autoload
 (defun format-all-buffer (&optional prompt)
   "Auto-format the source code in the current buffer.
 


### PR DESCRIPTION
Added a `format-all-region-or-buffer` command. I don't know any reason to not have it, and the benefit is that you can bind it to a single key and it'll do the right thing.

I used the suffix `-region-or-buffer`rather than `-buffer-or-region` for consistency with the `elisp-eval-region-or-buffer` function introduced in Emacs 29.1