### PR TITLE
Fix format-all--save-line-number column logic

### DIFF
--- a/format-all.el
+++ b/format-all.el
@@ -1512,14 +1512,20 @@ STATUS and ERROR-OUTPUT come from the formatter."
 (defun format-all--save-line-number (thunk)
   "Internal helper function to run THUNK and go back to the same line."
   (let ((old-line-number (line-number-at-pos))
-        (old-column (current-column))
+        ;; NOTE: Not the same as what's returned by `current-column'.
+        ;; Column refers to the width of the character, and point
+        ;; refers to actual character.  For example, if you go over a
+        ;; tab character, point will increase by 1, but the column
+        ;; with increase by 8 (assuming the width of tab is set to 8).
+        (old-line-position (- (point) (line-beginning-position)))
+
         (old-window (selected-window))
         (old-window-start (window-start)))
     (funcall thunk)
     (goto-char (point-min))
     (forward-line (1- old-line-number))
-    (let ((line-length (- (point-at-eol) (point-at-bol))))
-      (goto-char (+ (point) (min old-column line-length))))
+    (let ((line-length (- (line-end-position) (line-beginning-position))))
+      (goto-char (+ (point) (min old-line-position line-length))))
     (set-window-start old-window old-window-start)))
 
 (defun format-all--save-mark-ring (thunk)


### PR DESCRIPTION
The current code has a bug where given that:

1. You're editing a file that uses tabs for indentation; and

2. You run either `format-all-buffer` or `format-all-region` and the command exits with an error, with no changes to the buffer

Then point will be moved a little to the right (depending on your width of tab). Since there are no changes to the code, the expected result would be that point stays in same place.

The reason for that is the code adds the old value of current-column to point, but point and column are not equivalent, because column is based on the width of a given character. For example, when you move through a tab character, point increases by 1 but column will increase by 8 (or whichever is the configured width for tabs).

So I fixed that and added a note in the code.

minor: Changed `point-at-eol` to `line-end-position` and `point-at-bol` to `line-beginning-position` for consistency.