### PR TITLE
minor: Declare indent of define-format-all-formatter

### DIFF
--- a/format-all.el
+++ b/format-all.el
@@ -590,6 +590,7 @@ FORMATTER is a symbol naming the formatter.  The name of the
 command used to run the formatter is usually a good choice.
 
 Consult the existing formatters for examples of BODY."
+  (declare (indent 1))
   (let (executable install languages features format)
     (cl-assert
      (equal (mapcar 'car body)


### PR DESCRIPTION
So that commands like `indent-pp-sexp` will indent the macro correctly.