### PR TITLE
minor: Display error buffer with with-help-window

### DIFF
--- a/format-all.el
+++ b/format-all.el
@@ -1487,14 +1487,9 @@ unofficial languages IDs are prefixed with \"_\"."
 
 ERROR-OUTPUT come from the formatter.  SHOW-ERRORS-P determines
 whether or not to display the errors buffer."
-  (save-selected-window
-    (with-current-buffer (get-buffer-create "*format-all-errors*")
-      (erase-buffer)
-      (insert error-output)
-      (if show-errors-p
-          (display-buffer (current-buffer))
-        (let ((error-window (get-buffer-window (current-buffer))))
-          (when error-window (quit-window nil error-window)))))))
+  (when show-errors-p
+    (with-help-window "*format-all-errors*"
+      (princ error-output))))
 
 (defun format-all--update-errors-buffer (status error-output)
   "Internal helper function to update *format-all-errors*.


### PR DESCRIPTION
This makes it so pressing `q` will kill the window, and it respects the customizable variable `help-window-select`.

---

With the current behavior, when format-all displays an error, I have to `C-x o` into the new window it created, and kill it with `C-x k`. I think the usability is much better if we display the error buffer in a help-like window. What do you think, @lassik ?