### PR TITLE
Implement "format region" feature for perltidy

### DIFF
--- a/format-all.el
+++ b/format-all.el
@@ -1108,7 +1108,7 @@ Consult the existing formatters for examples of BODY."
   (:install "cpan install Perl::Tidy")
   (:languages "Perl")
   (:features)
-  (:format (format-all--buffer-easy executable)))
+  (:format (format-all--buffer-easy executable "--standard-error-output")))
 
 (define-format-all-formatter pgformatter
   (:executable "pg_format")


### PR DESCRIPTION
Context: perltidy can take a code block in its stdin, and it will return it properly formatted. It doesn't need to be the source code of an entire file.

In this commit, we make a few changes to allow passing in just the active region's code to the formatter, and then replacing the region with the output of the formatter. Then, we use that to enable "format region" for perltidy.

With the changes in this commit, we should also be able to enable "format region" for other formatters, as long as they can accept a code block (not necessarily an entire file's source code) and return that block properly formatted.

---

Note: this depends on https://github.com/lassik/emacs-format-all-the-code/pull/229 being merged to master first.