### PR TITLE
scalafmt: Add --stdout as workaround for odd behaviour

### DIFF
--- a/format-all.el
+++ b/format-all.el
@@ -1266,7 +1266,7 @@ Consult the existing formatters for examples of BODY."
   (:features)
   (:format
    (format-all--buffer-easy
-    executable "--stdin" "--non-interactive" "--quiet")))
+    executable "--stdin" "--non-interactive" "--quiet" "--stdout")))
 
 (define-format-all-formatter shfmt
   (:executable "shfmt")


### PR DESCRIPTION
Sometimes, scalafmt does not produce formatted output to stdout with only the `--stdin` flag provided. For example, this happens when there are no formatting changes required to be made to the file. As-is, this causes the formatter to clear the buffer when there are no formatting changes required.

As a workaround, adding the `--stdout` flag ensures that output is always put on stdout.

See https://github.com/scalameta/scalafmt/issues/3632 for more information.