### PR TITLE
Add formatter: hclfmt for hashicorp HCL files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Supported languages
 * **GraphQL** ([*prettier*](https://prettier.io/), [*prettierd*](https://github.com/fsouza/prettierd))
 * **Haskell** ([*brittany*](https://github.com/lspitzner/brittany), [*fourmolu*](https://github.com/fourmolu/fourmolu), [*hindent*](https://github.com/commercialhaskell/hindent), [*ormolu*](https://github.com/tweag/ormolu), [*stylish-haskell*](https://github.com/jaspervdj/stylish-haskell))
 * **HTML/XHTML/XML** ([*tidy*](http://www.html-tidy.org/))
+* **HCL** ([*hclfmt*](https://github.com/hashicorp/hcl/tree/main/cmd/hclfmt))
 * **Java** ([*clang-format*](https://clang.llvm.org/docs/ClangFormat.html), [*astyle*](http://astyle.sourceforge.net/))
 * **JavaScript/JSON/JSX** ([*prettier*](https://prettier.io/), [*standard*](https://standardjs.com/), [*prettierd*](https://github.com/fsouza/prettierd), [*deno*](https://deno.land/manual/tools/formatter))
 * **Jsonnet** ([*jsonnetfmt*](https://jsonnet.org/))

--- a/format-all.el
+++ b/format-all.el
@@ -55,6 +55,7 @@
 ;; - Go (gofmt, goimports)
 ;; - GraphQL (prettier, prettierd)
 ;; - Haskell (brittany, fourmolu, hindent, ormolu, stylish-haskell)
+;; - HCL (hclfmt)
 ;; - HTML/XHTML/XML (tidy)
 ;; - Java (clang-format, astyle)
 ;; - JavaScript/JSON/JSX (prettier, standard, prettierd, deno)
@@ -152,6 +153,7 @@
     ("Go" gofmt)
     ("GraphQL" prettier)
     ("Haskell" brittany)
+    ("HCL" hclfmt)
     ("HTML" html-tidy)
     ("HTML+EEX" mix-format)
     ("HTML+ERB" erb-format)
@@ -962,6 +964,13 @@ Consult the existing formatters for examples of BODY."
   (:executable "goimports")
   (:install "go get golang.org/x/tools/cmd/goimports")
   (:languages "Go")
+  (:features)
+  (:format (format-all--buffer-easy executable)))
+
+(define-format-all-formatter hclfmt
+  (:executable "hclfmt")
+  (:install "go install github.com/hashicorp/hcl/v2/cmd/hclfmt@latest")
+  (:languages "HCL")
   (:features)
   (:format (format-all--buffer-easy executable)))
 


### PR DESCRIPTION
The PR adds support for formatting hashcorp hcl files with the help of `hclfmt`.

Tested it with `M-x load-file` and running `format-all-buffer`. 
