### PR TITLE
sqlformat should use option -r

### DIFF
--- a/format-all.el
+++ b/format-all.el
@@ -1342,7 +1342,7 @@ Consult the existing formatters for examples of BODY."
                                  'utf-8)))
           (process-environment (cons (concat "PYTHONIOENCODING=" oenc)
                                      process-environment)))
-     (format-all--buffer-easy executable "--encoding" ienc "-"))))
+     (format-all--buffer-easy executable "-r" "--encoding" ienc "-"))))
 
 (define-format-all-formatter standard
   (:executable "standard")


### PR DESCRIPTION
Before, sqlformat almost does nothing when format sql files. After adding the -r option, the sql can be correctly formatted.

For example, using SQL 
```sql
select l_orderkey   from lineitem
 where exists (        select *
          from orders
         where o_orderkey = l_orderkey
       )
    or l_linenumber in (1,2,3);
```
Without this change, the sql is not formatted. After this change, it can be formatted to 
```sql
select l_orderkey
from lineitem
where exists
    (select *
     from orders
     where o_orderkey = l_orderkey )
  or l_linenumber in (1,
                      2,
                      3);
```