### PR TITLE
rename emacs-hy to hy-mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Supported languages
 * **HCL** ([*hclfmt*](https://github.com/hashicorp/hcl/tree/main/cmd/hclfmt))
 * **HLSL** ([*clang-format*](https://clang.llvm.org/docs/ClangFormat.html))
 * **HTML/XHTML/XML** ([*tidy*](http://www.html-tidy.org/))
-* **Hy** (Emacs)
+* **Hy** ([*hy-mode*](https://github.com/hylang/hy-mode))
 * **Java** ([*clang-format*](https://clang.llvm.org/docs/ClangFormat.html), [*astyle*](http://astyle.sourceforge.net/))
 * **JavaScript/JSON/JSX** ([*prettier*](https://prettier.io/), [*standard*](https://standardjs.com/), [*prettierd*](https://github.com/fsouza/prettierd), [*deno*](https://deno.land/manual/tools/formatter))
 * **Jsonnet** ([*jsonnetfmt*](https://jsonnet.org/))

--- a/format-all.el
+++ b/format-all.el
@@ -59,7 +59,7 @@
 ;; - HCL (hclfmt)
 ;; - HLSL (clang-format)
 ;; - HTML/XHTML/XML (tidy)
-;; - Hy (Emacs)
+;; - Hy (hy-mode)
 ;; - Java (clang-format, astyle)
 ;; - JavaScript/JSON/JSX (prettier, standard, prettierd, deno)
 ;; - Jsonnet (jsonnetfmt)
@@ -161,7 +161,7 @@
     ("HTML" html-tidy)
     ("HTML+EEX" mix-format)
     ("HTML+ERB" erb-format)
-    ("Hy" emacs-hy)
+    ("Hy" hy-mode)
     ("Java" clang-format)
     ("JavaScript" prettier)
     ("JSON" prettier)
@@ -892,18 +892,6 @@ Consult the existing formatters for examples of BODY."
   (:features)
   (:format (format-all--buffer-native 'bibtex-mode 'bibtex-sort-buffer)))
 
-(define-format-all-formatter emacs-hy
-  (:executable)
-  (:install)
-  (:languages "Hy")
-  (:features region)
-  (:format
-   (format-all--buffer-native
-    'hy-mode
-    (if region
-        (lambda () (indent-region (car region) (cdr region)))
-      (lambda () (indent-region (point-min) (point-max)))))))
-
 (define-format-all-formatter emacs-lisp
   (:executable)
   (:install)
@@ -1014,6 +1002,18 @@ Consult the existing formatters for examples of BODY."
     "--tidy-mark" "no"
     "-indent"
     (when (equal language "XML") "-xml"))))
+
+(define-format-all-formatter hy-mode
+  (:executable)
+  (:install)
+  (:languages "Hy")
+  (:features region)
+  (:format
+   (format-all--buffer-native
+    'hy-mode
+    (if region
+        (lambda () (indent-region (car region) (cdr region)))
+      (lambda () (indent-region (point-min) (point-max)))))))
 
 (define-format-all-formatter isort
   (:executable "isort")


### PR DESCRIPTION
I am the contributor to this piece of code, and after reviewing the
entire file recently, I think that perhaps changing "emacs-hy" to
"hy-mode" would be more appropriate?

Additionally, I think it might be better to provide a default
formatter for all languages: copy the buffer or region, switch to the
default major mode, then call indent-region/delete-trailing-whitespace,
and finally merge back into the original buffer.