### PR TITLE
feat: add google-java-format for java

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Supported languages
 * **HLSL** ([*clang-format*](https://clang.llvm.org/docs/ClangFormat.html))
 * **HTML/XHTML/XML** ([*tidy*](http://www.html-tidy.org/))
 * **Hy** (Emacs)
-* **Java** ([*clang-format*](https://clang.llvm.org/docs/ClangFormat.html), [*astyle*](http://astyle.sourceforge.net/)), [*google-java-format*](https://github.com/google/google-java-format)
+* **Java** ([*google-java-format*](https://github.com/google/google-java-format), [*clang-format*](https://clang.llvm.org/docs/ClangFormat.html), [*astyle*](http://astyle.sourceforge.net/))
 * **JavaScript/JSON/JSX** ([*prettier*](https://prettier.io/), [*standard*](https://standardjs.com/), [*prettierd*](https://github.com/fsouza/prettierd), [*deno*](https://deno.land/manual/tools/formatter))
 * **Jsonnet** ([*jsonnetfmt*](https://jsonnet.org/))
 * **Kotlin** ([*ktlint*](https://github.com/shyiko/ktlint))

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Supported languages
 * **HLSL** ([*clang-format*](https://clang.llvm.org/docs/ClangFormat.html))
 * **HTML/XHTML/XML** ([*tidy*](http://www.html-tidy.org/))
 * **Hy** (Emacs)
-* **Java** ([*google-java-format*](https://github.com/google/google-java-format), [*clang-format*](https://clang.llvm.org/docs/ClangFormat.html), [*astyle*](http://astyle.sourceforge.net/))
+* **Java** ([*astyle*](http://astyle.sourceforge.net/), [*clang-format*](https://clang.llvm.org/docs/ClangFormat.html), [*google-java-format*](https://github.com/google/google-java-format))
 * **JavaScript/JSON/JSX** ([*prettier*](https://prettier.io/), [*standard*](https://standardjs.com/), [*prettierd*](https://github.com/fsouza/prettierd), [*deno*](https://deno.land/manual/tools/formatter))
 * **Jsonnet** ([*jsonnetfmt*](https://jsonnet.org/))
 * **Kotlin** ([*ktlint*](https://github.com/shyiko/ktlint))

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Supported languages
 * **HLSL** ([*clang-format*](https://clang.llvm.org/docs/ClangFormat.html))
 * **HTML/XHTML/XML** ([*tidy*](http://www.html-tidy.org/))
 * **Hy** (Emacs)
-* **Java** ([*clang-format*](https://clang.llvm.org/docs/ClangFormat.html), [*astyle*](http://astyle.sourceforge.net/))
+* **Java** ([*clang-format*](https://clang.llvm.org/docs/ClangFormat.html), [*astyle*](http://astyle.sourceforge.net/)), [*google-java-format*](https://github.com/google/google-java-format)
 * **JavaScript/JSON/JSX** ([*prettier*](https://prettier.io/), [*standard*](https://standardjs.com/), [*prettierd*](https://github.com/fsouza/prettierd), [*deno*](https://deno.land/manual/tools/formatter))
 * **Jsonnet** ([*jsonnetfmt*](https://jsonnet.org/))
 * **Kotlin** ([*ktlint*](https://github.com/shyiko/ktlint))

--- a/format-all.el
+++ b/format-all.el
@@ -60,7 +60,7 @@
 ;; - HLSL (clang-format)
 ;; - HTML/XHTML/XML (tidy)
 ;; - Hy (Emacs)
-;; - Java (google-java-format, clang-format, astyle)
+;; - Java (astyle, clang-format, google-java-format)
 ;; - JavaScript/JSON/JSX (prettier, standard, prettierd, deno)
 ;; - Jsonnet (jsonnetfmt)
 ;; - Kotlin (ktlint)
@@ -662,13 +662,6 @@ Consult the existing formatters for examples of BODY."
             (let ((astylerc (format-all--locate-file ".astylerc")))
               (when astylerc (concat "--options=" astylerc))))))
 
-(define-format-all-formatter google-java-format
-  (:executable "google-java-format")
-  (:install)
-  (:languages "Java")
-  (:features)
-  (:format (format-all--buffer-easy executable "-")))
-
 (define-format-all-formatter atsfmt
   (:executable "atsfmt")
   (:install "cabal new-install ats-format --happy-options='-gcsa' -O2")
@@ -991,6 +984,13 @@ Consult the existing formatters for examples of BODY."
   (:languages "Go")
   (:features)
   (:format (format-all--buffer-easy executable)))
+
+(define-format-all-formatter google-java-format
+  (:executable "google-java-format")
+  (:install)
+  (:languages "Java")
+  (:features)
+  (:format (format-all--buffer-easy executable "-")))
 
 (define-format-all-formatter hclfmt
   (:executable "hclfmt")

--- a/format-all.el
+++ b/format-all.el
@@ -60,7 +60,7 @@
 ;; - HLSL (clang-format)
 ;; - HTML/XHTML/XML (tidy)
 ;; - Hy (Emacs)
-;; - Java (clang-format, astyle)
+;; - Java (clang-format, astyle, google-java-format)
 ;; - JavaScript/JSON/JSX (prettier, standard, prettierd, deno)
 ;; - Jsonnet (jsonnetfmt)
 ;; - Kotlin (ktlint)
@@ -292,7 +292,7 @@ association list. Using \".dir-locals.el\" is convenient since
 the rules for an entire source tree can be given in one file.")
 
 (define-error 'format-all-executable-not-found
-  "Formatter not found")
+              "Formatter not found")
 
 (defun format-all--proper-list-p (object)
   "Return t if OBJECT is a proper list, nil otherwise."
@@ -661,6 +661,13 @@ Consult the existing formatters for examples of BODY."
             executable
             (let ((astylerc (format-all--locate-file ".astylerc")))
               (when astylerc (concat "--options=" astylerc))))))
+
+(define-format-all-formatter google-java-format
+  (:executable "google-java-format")
+  (:install)
+  (:languages "Java")
+  (:features)
+  (:format (format-all--buffer-easy executable)))
 
 (define-format-all-formatter atsfmt
   (:executable "atsfmt")

--- a/format-all.el
+++ b/format-all.el
@@ -60,7 +60,7 @@
 ;; - HLSL (clang-format)
 ;; - HTML/XHTML/XML (tidy)
 ;; - Hy (Emacs)
-;; - Java (clang-format, astyle, google-java-format)
+;; - Java (google-java-format, clang-format, astyle)
 ;; - JavaScript/JSON/JSX (prettier, standard, prettierd, deno)
 ;; - Jsonnet (jsonnetfmt)
 ;; - Kotlin (ktlint)
@@ -162,7 +162,7 @@
     ("HTML+EEX" mix-format)
     ("HTML+ERB" erb-format)
     ("Hy" emacs-hy)
-    ("Java" clang-format)
+    ("Java" google-java-format)
     ("JavaScript" prettier)
     ("JSON" prettier)
     ("JSON5" prettier)
@@ -292,7 +292,7 @@ association list. Using \".dir-locals.el\" is convenient since
 the rules for an entire source tree can be given in one file.")
 
 (define-error 'format-all-executable-not-found
-              "Formatter not found")
+  "Formatter not found")
 
 (defun format-all--proper-list-p (object)
   "Return t if OBJECT is a proper list, nil otherwise."
@@ -667,7 +667,7 @@ Consult the existing formatters for examples of BODY."
   (:install)
   (:languages "Java")
   (:features)
-  (:format (format-all--buffer-easy executable)))
+  (:format (format-all--buffer-easy executable "-")))
 
 (define-format-all-formatter atsfmt
   (:executable "atsfmt")


### PR DESCRIPTION
add built-in support for google-java-format for java.

If it sounds good to you, I can further update default formatter of java to this one. google-java-format seems to be the most adopted formatter nowadays.