### PR TITLE
feat: add support for sqlfluff

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Supported languages
 * **Shell script** ([*beautysh*](https://github.com/lovesegfault/beautysh), [*shfmt*](https://github.com/mvdan/sh))
 * **Snakemake** ([*snakefmt*](https://github.com/snakemake/snakefmt))
 * **Solidity** ([*prettier plugin*](https://github.com/prettier-solidity/prettier-plugin-solidity))
-* **SQL** ([*pgformatter*](https://github.com/darold/pgFormatter), [*sqlformat*](https://pypi.org/project/sqlparse/))
+* **SQL** ([*pgformatter*](https://github.com/darold/pgFormatter), [*sqlformat*](https://pypi.org/project/sqlparse/), [*sqlfluff*](https://sqlfluff.com))
 * **Svelte** ([*prettier plugin*](https://github.com/sveltejs/prettier-plugin-svelte))
 * **Swift** ([*swiftformat*](https://github.com/nicklockwood/SwiftFormat))
 * **Terraform** ([*terraform fmt*](https://www.terraform.io/docs/commands/fmt.html))

--- a/format-all.el
+++ b/format-all.el
@@ -87,7 +87,7 @@
 ;; - Shell script (beautysh, shfmt)
 ;; - Snakemake (snakefmt)
 ;; - Solidity (prettier plugin)
-;; - SQL (pgformatter, sqlformat)
+;; - SQL (pgformatter, sqlformat, sqlfluff)
 ;; - Svelte (prettier plugin)
 ;; - Swift (swiftformat)
 ;; - Terraform (terraform fmt)
@@ -1362,6 +1362,13 @@ Consult the existing formatters for examples of BODY."
           (process-environment (cons (concat "PYTHONIOENCODING=" oenc)
                                      process-environment)))
      (format-all--buffer-easy executable "--encoding" ienc "-"))))
+
+(define-format-all-formatter sqlfluff
+  (:executable "sqlfluff")
+  (:install "pip install sqlfluff")
+  (:languages "SQL")
+  (:features)
+  (:format (format-all--buffer-easy executable "fix" "--nocolor" "--dialect=postgres" "-")))
 
 (define-format-all-formatter standard
   (:executable "standard")


### PR DESCRIPTION
This pull request adds support for [SQLFluff](https://sqlfluff.com/).
There are some problems though. The only way I found to format files with a custom configuration template (which is probably what most users working on production databases would like) was:

```sql
(add-hook 'sql-mode-hook
  (lambda ()
    (define-format-all-formatter sqlfluff
      (:executable "sqlfluff")
      (:install "pip install sqlfluff")
      (:languages "SQL")
      (:features)
      (:format (format-all--buffer-easy executable 
                 "fix"
                 "--config=/path/to/config.ctg"
                 "--nocolor" "-")
      )
    )
  )
)

```