### PR TITLE
Add `meson fmt` for Meson

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Supported languages
 * **Ledger** ([*ledger-mode*](https://github.com/ledger/ledger-mode))
 * **Lua** ([*lua-fmt*](https://github.com/trixnz/lua-fmt), [stylua](https://github.com/JohnnyMorganz/StyLua),  [*prettier plugin*](https://github.com/prettier/plugin-lua))
 * **Markdown** ([*prettier*](https://prettier.io/), [*prettierd*](https://github.com/fsouza/prettierd), [*deno*](https://deno.land/manual/tools/formatter))
-* **Meson** ([*muon fmt*](https://sr.ht/~lattis/muon/))
+* **Meson** ([*muon fmt*](https://sr.ht/~lattis/muon/), [*meson format*](https://mesonbuild.com/))
 * **Nginx** ([*nginxfmt*](https://github.com/slomkowski/nginx-config-formatter))
 * **Nix** ([*nixpkgs-fmt*](https://github.com/nix-community/nixpkgs-fmt), [*nixfmt*](https://github.com/serokell/nixfmt),
 [*alejandra*](https://github.com/kamadorueda/alejandra))

--- a/format-all.el
+++ b/format-all.el
@@ -68,7 +68,7 @@
 ;; - Ledger (ledger-mode)
 ;; - Lua (lua-fmt, stylua, prettier plugin)
 ;; - Markdown (prettier, prettierd, deno)
-;; - Meson (muon fmt)
+;; - Meson (muon fmt, meson format)
 ;; - Nginx (nginxfmt)
 ;; - Nix (nixpkgs-fmt, nixfmt, alejandra)
 ;; - OCaml (ocp-indent, ocamlformat)
@@ -1106,6 +1106,13 @@ Consult the existing formatters for examples of BODY."
   (:languages "Meson")
   (:features)
   (:format (format-all--buffer-easy executable "fmt" "-")))
+
+(define-format-all-formatter meson-format
+  (:executable "meson")
+  (:install  "pip install meson")
+  (:languages "Meson")
+  (:features)
+  (:format (format-all--buffer-easy executable "format" "--editor-config" "-")))
 
 (define-format-all-formatter nginxfmt
   (:executable "nginxfmt")


### PR DESCRIPTION
Also enable flag to use editorconfig by default, this is often already implied by other formatters.