### PR TITLE
Fix `csharpier`

### DIFF
--- a/format-all.el
+++ b/format-all.el
@@ -799,11 +799,11 @@ Consult the existing formatters for examples of BODY."
   (:format (format-all--buffer-easy executable "tool" "format" "-")))
 
 (define-format-all-formatter csharpier
-  (:executable "dotnet-csharpier")
+  (:executable "csharpier")
   (:install "dotnet install -g csharpier")
   (:languages "C#")
   (:features)
-  (:format (format-all--buffer-easy executable "--write-stdout")))
+  (:format (format-all--buffer-easy executable "format" "--write-stdout")))
 
 (define-format-all-formatter dart-format
   (:executable "dart")


### PR DESCRIPTION
As noted in #221, there have been breaking changes to the CLI of `csharpier`. This PR incorporates the changes. This will break the compatibility for older version of `csharpier`.