### PR TITLE
Add rubyfmt for Ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Supported languages
 * **Racket** ([*raco fmt*](https://docs.racket-lang.org/fmt/))
 * **Reason** ([*bsrefmt*](https://github.com/glennsl/bs-refmt))
 * **ReScript** ([*rescript format*](https://www.npmjs.com/package/rescript))
-* **Ruby** ([*rubocop*](https://github.com/rubocop/rubocop), [*rufo*](https://github.com/ruby-formatter/rufo), [*standardrb*](https://github.com/testdouble/standard), [*stree (syntax_tree)*](https://github.com/ruby-syntax-tree/syntax_tree))
+* **Ruby** ([*rubocop*](https://github.com/rubocop/rubocop), [*rubyfmt*](https://github.com/fables-tales/rubyfmt), [*rufo*](https://github.com/ruby-formatter/rufo), [*standardrb*](https://github.com/testdouble/standard), [*stree (syntax_tree)*](https://github.com/ruby-syntax-tree/syntax_tree))
 * **Rust** ([*rustfmt*](https://github.com/rust-lang-nursery/rustfmt))
 * **Scala** ([*scalafmt*](https://github.com/scalameta/scalafmt))
 * **Shell script** ([*beautysh*](https://github.com/lovesegfault/beautysh), [*shfmt*](https://github.com/mvdan/sh))

--- a/format-all.el
+++ b/format-all.el
@@ -81,7 +81,7 @@
 ;; - Racket (raco-fmt)
 ;; - Reason (bsrefmt)
 ;; - ReScript (rescript)
-;; - Ruby (rubocop, rufo, standardrb, stree)
+;; - Ruby (rubocop, rubyfmt, rufo, standardrb, stree)
 ;; - Rust (rustfmt)
 ;; - Scala (scalafmt)
 ;; - Shell script (beautysh, shfmt)
@@ -1317,6 +1317,18 @@ Consult the existing formatters for examples of BODY."
     "--format" "quiet"
     "--stderr"
     "--stdin" (or (buffer-file-name) (buffer-name)))))
+
+(define-format-all-formatter rubyfmt
+  (:executable "rubyfmt")
+  (:install
+   (macos "brew install rubyfmt"))
+  (:languages "Ruby")
+  (:features)
+  (:format
+   (format-all--buffer-easy
+    executable
+    (when (buffer-file-name)
+      (list "--stdin-filepath" (buffer-file-name))))))
 
 (define-format-all-formatter ruff
   (:executable "ruff")


### PR DESCRIPTION
[rubyfmt](https://github.com/fables-tales/rubyfmt) is ultra-fast and very suitable for auto-formatting Ruby code.

https://stripe.dev/blog/formatting-an-entire-25-million-line-codebase-overnight-the-rubyfmt-story