### PR TITLE
perltidy: accept 2 as successful exit status

### DIFF
--- a/format-all.el
+++ b/format-all.el
@@ -1347,7 +1347,8 @@ accepting connections."
   (:languages "Perl")
   (:features region)
   (:format
-   (format-all--buffer-easy
+   (format-all--buffer-hard
+    '(0 2) nil nil
     executable
     "--standard-error-output"
     (when region


### PR DESCRIPTION
From perltidy(1):

  An exit value of 2 indicates that perltidy was able to run to
  completion but there there are (1) warning messages in the standard
  error output related to parameter errors or problems and/or (2)
  warning messages in the perltidy error file(s) relating to possible
  syntax errors in one or more of the source script(s) being tidied.
  When multiple files are being processed, an error detected in any
  single file will produce this type of exit condition.

In fact, some warnings triggering exit 2 don't even have anything to
do with the formatting, e.g., not finding a config file in one of the
expected locations (despite having found it elsewhere and successfully
formatting the buffer).